### PR TITLE
MAN-383: Restore __linux__ test for err.h inclusion

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -36,7 +36,7 @@ class ArgTable3(ConanFile):
     name = 'argtable3'
     description = 'A single-file, ANSI C, command-line parsing library that parses GNU-style command-line options.'
     url = 'https://github.com/argtable/argtable3'
-    version = tools.load('version.txt').strip() + '-2'
+    version = tools.load('version.txt').strip() + '-3'
     license = 'BSD 3-Clause'
     settings = 'os', 'compiler', 'build_type', 'arch'
     options = {

--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -377,7 +377,7 @@ static const char illoptstring[] = "unknown option -- %s";
 
 
 
-#ifdef _WIN32
+#if !defined(__linux__)
 /* Windows needs warnx().  We change the definition though:
  *  1. (another) global is defined, opterrmsg, which holds the error message
  *  2. errors are always printed out on stderr w/o the program name


### PR DESCRIPTION
- The guard for err.h inclusion was incorrectly reverted to _WIN32 in a prior merge, and is restored here for proper building on non-linux (including embedded) systems.
- The pre-release version in the conan recipe is bumped to -3.